### PR TITLE
Add optional scoring mode with all-out cap and mid-innings resume

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -1,6 +1,6 @@
 # Cricket Umpire Counter - Product Requirements Document
 
-A mobile-optimized cricket umpiring tool that tracks balls, overs, wickets with customizable wide and no-ball handling rules.
+A mobile-optimized cricket umpiring tool that tracks balls, overs, wickets — and, with optional scoring mode, the running team total — with customizable wide and no-ball handling rules.
 
 **Experience Qualities**: 
 1. **Reliable** - Accurate counting with clear visual feedback for critical match decisions
@@ -27,11 +27,27 @@ A mobile-optimized cricket umpiring tool that tracks balls, overs, wickets with 
 - Success criteria: Seamless over transitions with persistent count
 
 **Wicket Counter**
-- Functionality: Track dismissals throughout the innings
+- Functionality: Track dismissals throughout the innings, capped at 10 (a full team)
 - Purpose: Monitor team's remaining batsmen and innings conclusion
 - Trigger: Dedicated wicket button for dismissals
-- Progression: Dismissal occurs → Tap wicket button → Counter increments → Visual confirmation
-- Success criteria: Accurate wicket tracking independent of ball count
+- Progression: Dismissal occurs → Tap wicket button → Counter increments → Visual confirmation. On the 10th wicket an "All out" popup confirms the innings is over and delivery buttons lock until reset/undo/resume.
+- Success criteria: Accurate wicket tracking independent of ball count; never exceeds 10; all-out is clearly signalled
+
+**Optional Scoring Mode**
+- Functionality: Track the running team total (runs / wickets) alongside overs, making the app engaging enough to score with while umpiring. On by default; easily turned off in Settings.
+- Purpose: Let umpires keep the score as well as officiate, without forcing it on those who only want ball/over/wicket counting.
+- Trigger: "Scoring mode" switch in Settings (default on).
+- Progression:
+  - **On**: The single "Legal Delivery" button is replaced by run buttons (`• 1 2 3 4 6` plus `5+` for unusual scores). Wide / No-ball / Bye / Leg-bye each open a quick run picker for runs taken. Wides and no-balls add a configurable penalty (default 1 run, set beside the re-bowl toggles). A prominent scoreboard shows `runs/wickets`, overs and current run rate, and the delivery-sequence chips show runs (e.g. `4`, `•`, `Wd+1`, `Nb+2`, `B2`, `Lb1`, `W`). To save space, the **Current Over Details** card is collapsed by default in scoring mode (tap its header to expand; a compact summary is shown while collapsed). When an over completes, the confirmation dialog also shows the **runs scored that over** and the **score total** (`runs/wickets`) while scoring is on.
+  - **Off**: The app behaves exactly as before — a single "Legal Delivery" button with Wide / No-ball / Wicket, no runs and no scoreboard, and the Current Over Details card expanded.
+- Success criteria: With scoring off the experience is unchanged; with scoring on the team total updates correctly for runs, extras (penalty + runs run), byes and leg-byes, and is restored by Undo.
+
+**Manual Set / Resume Score (mid-innings pickup)**
+- Functionality: Manually enter the current runs (when scoring on), wickets and overs (in `overs.balls` notation, e.g. `11.3`) so an umpire can pick up part-way through an innings.
+- Purpose: Officials often take over mid-innings and need to start from the current match state, not zero.
+- Trigger: "Set / Resume Score" button on the main screen and a matching link in Settings.
+- Progression: Open dialog → Enter runs / wickets / overs → Inline validation flags bad input live (wickets must be less than 10; overs in `overs.balls` with balls 0–5, so `12.6` or `11.9` are rejected; runs ≥ 0) and the confirm button stays disabled until all fields are valid → Existing data triggers an overwrite warning → Confirm → State is set and the current over's ball-by-ball and undo history are cleared (prior detail is unknown).
+- Success criteria: The score, wickets and overs.balls reflect the entered values, impossible values cannot be submitted, and play continues correctly from that point.
 
 **Wide/No-Ball Rule Toggle**
 - Functionality: Configure whether wides and no-balls consume balls from the over
@@ -49,6 +65,8 @@ A mobile-optimized cricket umpiring tool that tracks balls, overs, wickets with 
 
 ## Edge Case Handling
 
+- **Innings complete (all out)** - Cap wickets at 10; on the 10th wicket show an "All out" popup and lock deliveries until reset, undo or resume
+- **Impossible manual entry** - Reject more than 9 wickets and invalid overs (e.g. `12.6`, `11.9`) inline before they can be applied
 - **Multiple extras in sequence** - Handle consecutive wides/no-balls without breaking over logic
 - **Accidental taps** - Provide undo functionality for the last action taken
 - **App backgrounding** - Persist all counter state when app loses focus

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cricket Umpire Counter
 
-A professional mobile-optimized cricket umpiring tool for tracking balls, overs, and wickets during live matches. Designed with cricket officials in mind, this Progressive Web App (PWA) provides reliable, efficient counting with customizable rules for different cricket formats.
+A professional mobile-optimized cricket umpiring tool for tracking balls, overs, wickets — and, with optional scoring mode, the running team total — during live matches. Designed with cricket officials in mind, this Progressive Web App (PWA) provides reliable, efficient counting with customizable rules for different cricket formats.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?logo=typescript&logoColor=white)](#)
@@ -19,6 +19,16 @@ The app is automatically deployed to GitHub Pages with a custom domain: **[https
 - **Over Counter**: Automatic over progression when 6 legal balls are completed
 - **Wicket Counter**: Independent wicket tracking throughout the innings
 - **Current Over Details**: Visual breakdown of deliveries, extras, and wickets in the current over
+
+### 🧮 Optional Scoring Mode
+- **Team Total**: Track the running `runs/wickets` and current run rate alongside overs — on by default, easily turned off in Settings
+- **Run Buttons**: With scoring on, record runs per ball (`• 1 2 3 4 6`, plus `5+` for unusual scores) in place of the single "Legal Delivery" button
+- **Extras & Byes**: Wide, No-ball, Bye and Leg-bye each open a quick run picker; wides and no-balls add a configurable penalty (default 1) set beside the re-bowl toggles
+- **All Out**: Wickets are capped at 10 — the 10th wicket triggers an "All out" popup and locks deliveries until you reset, undo or resume
+- **Collapsible Over Details**: The Current Over Details card is collapsed by default in scoring mode to save space (tap its header to expand)
+- **Over-complete recap**: When an over finishes, the confirmation popup shows the runs scored that over and the running score total (`runs/wickets`) while scoring is on
+- **Set / Resume Score**: Pick up mid-innings by manually entering the current runs, wickets and overs (`overs.balls`, e.g. `11.3`), with live validation that blocks impossible values (10+ wickets, `12.6`, `11.9`, …)
+- **Off = unchanged**: With scoring off the app behaves exactly as before — a single "Legal Delivery" button, no runs and no scoreboard
 
 ### ⚙️ Customizable Rules
 - **Wide Ball Rules**: Toggle whether wides consume balls from the over or are re-bowled
@@ -76,16 +86,19 @@ Visit the deployed app in your mobile browser and use "Add to Home Screen" for t
 
 ### Basic Operation
 1. **Start New Match**: Use "Reset All" to clear all counters
-2. **Record Deliveries**: 
-   - Tap "Legal Delivery" for standard balls
-   - Use "Wide" or "No-ball" for extras (respects your rule settings)
-   - Tap "Wicket" for dismissals
+2. **Record Deliveries**:
+   - With **scoring on** (default): tap a run button (`• 1 2 3 4 6` or `5+`) for each legal ball; use "Wide", "No-ball", "Bye" or "Leg-bye" for extras (a run picker appears); tap "Out" for dismissals
+   - With **scoring off**: tap "Legal Delivery" for standard balls, "Wide" or "No-ball" for extras, and "Wicket" for dismissals
 3. **Over Completion**: Confirm when 6 legal balls are reached to advance to the next over
-4. **Undo Mistakes**: Use the undo button to reverse the last action
+4. **Undo Mistakes**: Use the undo button to reverse the last action (restores runs too)
+5. **Pick Up Mid-Innings**: Tap "Set / Resume Score" to enter the current runs, wickets and overs (`overs.balls`, e.g. `11.3`)
 
 ### Settings Configuration
 - Access settings via the gear icon in the top-right
+- Toggle **Scoring mode** on or off (default on)
+- Set the runs added per wide and per no-ball (shown when scoring is on)
 - Toggle wide and no-ball rebowl rules to match your format
+- Open "Set / resume score…" to enter the current match state
 - Settings are saved automatically and persist between sessions
 
 ### Rule Examples

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { 
   Dialog, 
@@ -18,16 +19,24 @@ import {
   Gear, 
   Target, 
   ArrowCounterClockwise,
-  Plus
+  Plus,
+  Pencil,
+  CaretDown,
+  CaretUp,
+  Warning
 } from '@phosphor-icons/react'
 import { useKV } from './hooks/useKV'
 import { toast } from 'sonner'
 
-type DeliveryType = 'legal' | 'wide' | 'no-ball' | 'wicket'
+type DeliveryType = 'legal' | 'wide' | 'no-ball' | 'wicket' | 'bye' | 'leg-bye'
+
+// Delivery types that ask "how many runs?" via the quick picker when scoring is on
+type PickerMode = 'legal' | 'wide' | 'no-ball' | 'bye' | 'leg-bye'
 
 interface DeliveryRecord {
   type: DeliveryType
   ballNumber: number // The ball number in this over when this delivery was made
+  runs: number // Total runs added to the team total for this delivery (incl. any penalty)
 }
 
 interface Action {
@@ -37,6 +46,7 @@ interface Action {
   ballsBefore: number
   oversBefore: number
   wicketsBefore: number
+  runsBefore: number
   currentOverDeliveriesBefore: DeliveryRecord[]
   timestamp: number
 }
@@ -46,6 +56,10 @@ function App() {
   const [balls, setBalls] = useKV('cricket-balls', 0)
   const [overs, setOvers] = useKV('cricket-overs', 0)  
   const [wickets, setWickets] = useKV('cricket-wickets', 0)
+  const [runs, setRuns] = useKV('cricket-runs', 0)
+  const [scoringEnabled, setScoringEnabled] = useKV('scoring-enabled', true)
+  const [widePenalty, setWidePenalty] = useKV('wide-penalty', 1)
+  const [noBallPenalty, setNoBallPenalty] = useKV('noball-penalty', 1)
   const [widesRebowled, setWidesRebowled] = useKV('wides-rebowled', true)
   const [noBallsRebowled, setNoBallsRebowled] = useKV('noballs-rebowled', true)
   const [currentOverDeliveries, setCurrentOverDeliveries] = useKV<DeliveryRecord[]>('current-over-deliveries', [])
@@ -56,16 +70,40 @@ function App() {
   const [showResetDialog, setShowResetDialog] = useState(false)
   const [showSettings, setShowSettings] = useState(false)
   const [showOverCompleteDialog, setShowOverCompleteDialog] = useState(false)
+  const [showAllOutDialog, setShowAllOutDialog] = useState(false)
+
+  // Current Over Details is collapsed by default when scoring (to save space)
+  const [overDetailsOpen, setOverDetailsOpen] = useState(!scoringEnabled)
+
+  // Run picker (used by 5+ and the extras buttons when scoring is on)
+  const [picker, setPicker] = useState<{ open: boolean; mode: PickerMode }>({ open: false, mode: 'legal' })
+  const [customRuns, setCustomRuns] = useState('')
+
+  // Manual "set / resume score" entry
+  const [showManualEntry, setShowManualEntry] = useState(false)
+  const [manualRuns, setManualRuns] = useState('')
+  const [manualWickets, setManualWickets] = useState('')
+  const [manualOvers, setManualOvers] = useState('')
 
   const ballsRemaining = 6 - balls
   const isOverComplete = balls >= 6
   const isAwaitingOverConfirmation = balls >= 6 && showOverCompleteDialog
   const totalDeliveriesInOver = currentOverDeliveries.length
-  const legalDeliveriesInOver = currentOverDeliveries.filter(d => d.type === 'legal' || d.type === 'wicket').length
+  const legalDeliveriesInOver = currentOverDeliveries.filter(d => d.type === 'legal' || d.type === 'wicket' || d.type === 'bye' || d.type === 'leg-bye').length
   const widesInOver = currentOverDeliveries.filter(d => d.type === 'wide').length
   const noBallsInOver = currentOverDeliveries.filter(d => d.type === 'no-ball').length
   const wicketsInOver = currentOverDeliveries.filter(d => d.type === 'wicket').length
+  const runsInOver = currentOverDeliveries.reduce((sum, d) => sum + d.runs, 0)
   const canUndo = actionHistory.length > 0
+
+  // Innings ends at 10 wickets ("all out"); lock deliveries while all out or
+  // while waiting to confirm a completed over.
+  const isAllOut = wickets >= 10
+  const deliveriesLocked = isAwaitingOverConfirmation || isAllOut
+
+  // Total legal balls bowled this innings, used for the current run rate
+  const totalLegalBalls = overs * 6 + balls
+  const runRate = totalLegalBalls > 0 ? runs / (totalLegalBalls / 6) : 0
 
   const addToHistory = (action: Omit<Action, 'id' | 'timestamp'>) => {
     const newAction: Action = {
@@ -79,7 +117,9 @@ function App() {
     setLastAction(newAction)
   }
 
-  const recordDelivery = (type: DeliveryType) => {
+  // runsScored = runs off the bat (legal) / runs run (bye, leg-bye) /
+  // extra runs run on top of the penalty (wide, no-ball). Ignored when scoring is off.
+  const recordDelivery = (type: DeliveryType, runsScored = 0) => {
     // Record the action for undo
     addToHistory({
       type: 'delivery',
@@ -87,6 +127,7 @@ function App() {
       ballsBefore: balls,
       oversBefore: overs,
       wicketsBefore: wickets,
+      runsBefore: runs,
       currentOverDeliveriesBefore: [...currentOverDeliveries]
     })
 
@@ -99,10 +140,27 @@ function App() {
       shouldIncrementBall = false
     }
 
+    // Work out the runs added to the team total for this delivery
+    let deliveryRuns = 0
+    if (scoringEnabled) {
+      if (type === 'wide') {
+        deliveryRuns = widePenalty + runsScored
+      } else if (type === 'no-ball') {
+        deliveryRuns = noBallPenalty + runsScored
+      } else {
+        deliveryRuns = runsScored
+      }
+    }
+
+    if (deliveryRuns > 0) {
+      setRuns((current) => current + deliveryRuns)
+    }
+
     // Add delivery to current over tracking
     const newDelivery: DeliveryRecord = {
       type,
-      ballNumber: totalDeliveriesInOver + 1
+      ballNumber: totalDeliveriesInOver + 1,
+      runs: deliveryRuns
     }
     
     setCurrentOverDeliveries((current) => [...current, newDelivery])
@@ -122,47 +180,70 @@ function App() {
 
     // Show feedback based on delivery type
     if (type === 'legal') {
-      toast.success('Legal delivery')
+      if (scoringEnabled) {
+        toast.success(runsScored === 0 ? 'Dot ball' : `${runsScored} run${runsScored > 1 ? 's' : ''}`)
+      } else {
+        toast.success('Legal delivery')
+      }
     } else if (type === 'wide') {
-      toast.warning(`Wide ${widesRebowled ? '(re-bowled)' : ''}`)
+      const suffix = widesRebowled ? ' (re-bowled)' : ''
+      toast.warning(scoringEnabled ? `Wide +${deliveryRuns}${suffix}` : `Wide${suffix}`)
     } else if (type === 'no-ball') {
-      toast.warning(`No-ball ${noBallsRebowled ? '(re-bowled)' : ''}`)
+      const suffix = noBallsRebowled ? ' (re-bowled)' : ''
+      toast.warning(scoringEnabled ? `No-ball +${deliveryRuns}${suffix}` : `No-ball${suffix}`)
+    } else if (type === 'bye') {
+      toast.success(`Bye +${runsScored}`)
+    } else if (type === 'leg-bye') {
+      toast.success(`Leg-bye +${runsScored}`)
     }
   }
 
   const recordWicket = () => {
+    // Innings is over once 10 wickets are down
+    if (wickets >= 10) {
+      toast.error('All out — innings over')
+      setShowAllOutDialog(true)
+      return
+    }
+
     addToHistory({
       type: 'wicket', 
       ballsBefore: balls,
       oversBefore: overs,
       wicketsBefore: wickets,
+      runsBefore: runs,
       currentOverDeliveriesBefore: [...currentOverDeliveries]
     })
     
     // Add wicket delivery to current over tracking as a wicket type
     const newDelivery: DeliveryRecord = {
       type: 'wicket',
-      ballNumber: totalDeliveriesInOver + 1
+      ballNumber: totalDeliveriesInOver + 1,
+      runs: 0
     }
     
     setCurrentOverDeliveries((current) => [...current, newDelivery])
     
-    // Increment wickets
-    setWickets((currentWickets) => currentWickets + 1)
+    // Increment wickets (capped at 10)
+    const newWickets = wickets + 1
+    setWickets(newWickets)
     
-    // Increment balls (wicket counts as a legal delivery)
-    setBalls((currentBalls) => {
-      const newBalls = currentBalls + 1
-      // Check if over is complete (6 legal balls)
+    // Wicket counts as a legal delivery
+    const newBalls = balls + 1
+    setBalls(newBalls)
+
+    if (newWickets >= 10) {
+      // All out — innings over. Show the all-out popup and skip the
+      // over-complete prompt even if this was the 6th ball.
+      setShowAllOutDialog(true)
+      toast.success('Wicket — all out!')
+    } else {
       if (newBalls >= 6) {
         // Show confirmation dialog instead of automatically progressing
         setShowOverCompleteDialog(true)
-        return newBalls // Keep balls at 6 until confirmed
       }
-      return newBalls
-    })
-    
-    toast.success('Wicket! (Legal delivery)')
+      toast.success('Wicket! (Legal delivery)')
+    }
   }
 
   const undoLastAction = () => {
@@ -182,10 +263,12 @@ function App() {
     setBalls(actionToUndo.ballsBefore)
     setOvers(actionToUndo.oversBefore)
     setWickets(actionToUndo.wicketsBefore)
+    setRuns(actionToUndo.runsBefore)
     setCurrentOverDeliveries(actionToUndo.currentOverDeliveriesBefore)
     
     // Close any open dialogs that might be affected
     setShowOverCompleteDialog(false)
+    setShowAllOutDialog(false)
     
     // Show appropriate toast
     if (actionToUndo.type === 'delivery') {
@@ -212,12 +295,141 @@ function App() {
     setBalls(0)
     setOvers(0)
     setWickets(0)
+    setRuns(0)
     setCurrentOverDeliveries([])
     setActionHistory([])
     setLastAction(null)
     setShowResetDialog(false)
+    setShowAllOutDialog(false)
     toast.success('Counters and history reset')
   }
+
+  // ---- Run picker (scoring mode) ----
+  const openPicker = (mode: PickerMode) => {
+    setCustomRuns('')
+    setPicker({ open: true, mode })
+  }
+
+  const handlePickRuns = (runsScored: number) => {
+    const mode = picker.mode
+    setPicker((p) => ({ ...p, open: false }))
+    setCustomRuns('')
+    recordDelivery(mode, runsScored)
+  }
+
+  // ---- Manual set / resume score ----
+  const hasMatchData =
+    runs > 0 || wickets > 0 || overs > 0 || balls > 0 || currentOverDeliveries.length > 0
+
+  const openManualEntry = () => {
+    setShowSettings(false)
+    setManualRuns(scoringEnabled ? String(runs) : '')
+    setManualWickets(String(wickets))
+    setManualOvers(`${overs}.${balls}`)
+    setShowManualEntry(true)
+  }
+
+  const applyManualEntry = () => {
+    // Parse overs in "O.B" notation (e.g. 11.3 = 11 overs, 3 balls into the next)
+    const [oversPartRaw, ballsPartRaw = '0'] = manualOvers.trim().split('.')
+    const oversPart = parseInt(oversPartRaw, 10)
+    const ballsPart = parseInt(ballsPartRaw, 10)
+    const wicketsVal = parseInt(manualWickets, 10)
+    const runsVal = scoringEnabled ? parseInt(manualRuns, 10) : 0
+
+    if (isNaN(oversPart) || oversPart < 0) {
+      toast.error('Enter overs as a whole number, e.g. 11')
+      return
+    }
+    if (isNaN(ballsPart) || ballsPart < 0 || ballsPart > 5) {
+      toast.error('Balls into the over must be 0–5 (e.g. 11.3)')
+      return
+    }
+    if (isNaN(wicketsVal) || wicketsVal < 0 || wicketsVal >= 10) {
+      toast.error('Wickets must be less than 10 (10 wickets = all out)')
+      return
+    }
+    if (scoringEnabled && (isNaN(runsVal) || runsVal < 0)) {
+      toast.error('Runs must be 0 or more')
+      return
+    }
+
+    setOvers(oversPart)
+    setBalls(ballsPart)
+    setWickets(wicketsVal)
+    setRuns(runsVal)
+    // Prior ball-by-ball is unknown, so clear this over's detail and undo history
+    setCurrentOverDeliveries([])
+    setActionHistory([])
+    setLastAction(null)
+    setShowOverCompleteDialog(false)
+    setShowManualEntry(false)
+    toast.success(
+      scoringEnabled
+        ? `Score set: ${runsVal}/${wicketsVal} · ${oversPart}.${ballsPart} ov`
+        : `Set to ${oversPart}.${ballsPart} ov · ${wicketsVal} down`
+    )
+  }
+
+  // Label + colour for a delivery chip in the over sequence
+  const chipFor = (d: DeliveryRecord): { label: string; className: string } => {
+    switch (d.type) {
+      case 'legal':
+        return { label: d.runs > 0 ? String(d.runs) : '•', className: 'bg-primary text-primary-foreground' }
+      case 'wicket':
+        return { label: 'W', className: 'bg-accent text-accent-foreground' }
+      case 'wide':
+        return { label: scoringEnabled ? `Wd+${d.runs}` : 'Wd', className: 'bg-yellow-200 text-yellow-800' }
+      case 'no-ball':
+        return { label: scoringEnabled ? `Nb+${d.runs}` : 'NB', className: 'bg-orange-200 text-orange-800' }
+      case 'bye':
+        return { label: `B${d.runs}`, className: 'bg-sky-200 text-sky-800' }
+      case 'leg-bye':
+        return { label: `Lb${d.runs}`, className: 'bg-indigo-200 text-indigo-800' }
+      default:
+        return { label: '?', className: 'bg-muted text-muted-foreground' }
+    }
+  }
+
+  // ---- Inline validation for the Set / Resume Score dialog ----
+  // Each returns an error string when the current input is non-empty and invalid,
+  // otherwise null. Empty fields are handled by the submit-enabled check below.
+  const manualWicketsError: string | null = (() => {
+    if (manualWickets.trim() === '') return null
+    const n = parseInt(manualWickets, 10)
+    if (isNaN(n)) return 'Enter a whole number'
+    if (n < 0) return 'Cannot be negative'
+    if (n >= 10) return 'Must be less than 10 (10 wickets = all out)'
+    return null
+  })()
+
+  const manualOversError: string | null = (() => {
+    const t = manualOvers.trim()
+    if (t === '') return null
+    const parts = t.split('.')
+    if (parts.length > 2) return 'Use overs.balls, e.g. 11.3'
+    const o = parseInt(parts[0], 10)
+    if (parts[0].trim() === '' || isNaN(o) || o < 0) return 'Enter whole overs, e.g. 11'
+    const ballsRaw = parts[1] !== undefined && parts[1] !== '' ? parts[1] : '0'
+    const b = parseInt(ballsRaw, 10)
+    if (isNaN(b) || b < 0) return 'Balls must be 0–5'
+    if (b > 5) return 'Max 6 legal balls per over — balls must be 0–5'
+    return null
+  })()
+
+  const manualRunsError: string | null = (() => {
+    if (!scoringEnabled) return null
+    if (manualRuns.trim() === '') return null
+    const n = parseInt(manualRuns, 10)
+    if (isNaN(n)) return 'Enter a whole number'
+    if (n < 0) return 'Cannot be negative'
+    return null
+  })()
+
+  const canApplyManual =
+    manualWicketsError === null && manualWickets.trim() !== '' &&
+    manualOversError === null && manualOvers.trim() !== '' &&
+    (!scoringEnabled || (manualRunsError === null && manualRuns.trim() !== ''))
 
   return (
     <div className="min-h-screen bg-background p-2 sm:p-4 pb-4 sm:pb-8">
@@ -235,36 +447,99 @@ function App() {
               <DialogHeader>
                 <DialogTitle>Settings</DialogTitle>
                 <DialogDescription>
-                  Configure wide and no-ball rules
+                  Configure scoring and wide / no-ball rules
                 </DialogDescription>
               </DialogHeader>
-              <div className="space-y-6 py-4">
+              <div className="space-y-5 py-4">
+                {/* Scoring mode */}
                 <div className="flex items-center justify-between">
                   <div className="space-y-1">
-                    <Label htmlFor="wides-rebowled">Wides re-bowled</Label>
+                    <Label htmlFor="scoring-enabled">Scoring mode</Label>
                     <p className="text-sm text-muted-foreground">
-                      Wide deliveries must be bowled again
+                      Track the team total with per-ball run buttons
                     </p>
                   </div>
                   <Switch
-                    id="wides-rebowled"
-                    checked={widesRebowled}
-                    onCheckedChange={setWidesRebowled}
+                    id="scoring-enabled"
+                    checked={scoringEnabled}
+                    onCheckedChange={setScoringEnabled}
                   />
                 </div>
-                <div className="flex items-center justify-between">
-                  <div className="space-y-1">
-                    <Label htmlFor="noballs-rebowled">No-balls re-bowled</Label>
-                    <p className="text-sm text-muted-foreground">
-                      No-ball deliveries must be bowled again
-                    </p>
+
+                <Separator />
+
+                {/* Wides */}
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-1">
+                      <Label htmlFor="wides-rebowled">Wides re-bowled</Label>
+                      <p className="text-sm text-muted-foreground">
+                        Wide deliveries must be bowled again
+                      </p>
+                    </div>
+                    <Switch
+                      id="wides-rebowled"
+                      checked={widesRebowled}
+                      onCheckedChange={setWidesRebowled}
+                    />
                   </div>
-                  <Switch
-                    id="noballs-rebowled" 
-                    checked={noBallsRebowled}
-                    onCheckedChange={setNoBallsRebowled}
-                  />
+                  {scoringEnabled && (
+                    <div className="flex items-center justify-between gap-3">
+                      <Label htmlFor="wide-penalty" className="text-sm font-normal text-muted-foreground">
+                        Runs added per wide
+                      </Label>
+                      <Input
+                        id="wide-penalty"
+                        type="number"
+                        min={0}
+                        inputMode="numeric"
+                        value={widePenalty}
+                        onChange={(e) => setWidePenalty(Math.max(0, parseInt(e.target.value, 10) || 0))}
+                        className="w-20 text-center"
+                      />
+                    </div>
+                  )}
                 </div>
+
+                {/* No-balls */}
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <div className="space-y-1">
+                      <Label htmlFor="noballs-rebowled">No-balls re-bowled</Label>
+                      <p className="text-sm text-muted-foreground">
+                        No-ball deliveries must be bowled again
+                      </p>
+                    </div>
+                    <Switch
+                      id="noballs-rebowled" 
+                      checked={noBallsRebowled}
+                      onCheckedChange={setNoBallsRebowled}
+                    />
+                  </div>
+                  {scoringEnabled && (
+                    <div className="flex items-center justify-between gap-3">
+                      <Label htmlFor="noball-penalty" className="text-sm font-normal text-muted-foreground">
+                        Runs added per no-ball
+                      </Label>
+                      <Input
+                        id="noball-penalty"
+                        type="number"
+                        min={0}
+                        inputMode="numeric"
+                        value={noBallPenalty}
+                        onChange={(e) => setNoBallPenalty(Math.max(0, parseInt(e.target.value, 10) || 0))}
+                        className="w-20 text-center"
+                      />
+                    </div>
+                  )}
+                </div>
+
+                <Separator />
+
+                <Button variant="outline" className="w-full" onClick={openManualEntry}>
+                  <Pencil size={16} className="mr-2" />
+                  Set / resume score…
+                </Button>
               </div>
             </DialogContent>
           </Dialog>
@@ -284,6 +559,16 @@ function App() {
                 <div className="text-lg font-semibold text-primary">
                   Current: {overs}.{balls}
                 </div>
+                {scoringEnabled && (
+                  <div className="flex items-center justify-center gap-2 text-sm">
+                    <span className="rounded-md bg-primary px-3 py-1 font-semibold text-primary-foreground">
+                      {runsInOver} run{runsInOver === 1 ? '' : 's'} this over
+                    </span>
+                    <span className="rounded-md bg-secondary px-3 py-1 font-semibold text-secondary-foreground">
+                      Score {runs}/{wickets}
+                    </span>
+                  </div>
+                )}
                 <div className="text-sm text-muted-foreground">
                   Total deliveries this over: {totalDeliveriesInOver}
                 </div>
@@ -302,6 +587,28 @@ function App() {
             </DialogFooter>
           </DialogContent>
         </Dialog>
+
+        {/* Scoreboard (scoring mode) */}
+        {scoringEnabled && (
+          <Card className="bg-primary text-primary-foreground py-3 sm:py-6">
+            <CardContent className="px-3 sm:px-6">
+              <div className="flex items-end justify-between gap-3">
+                <div>
+                  <div className="text-[10px] sm:text-xs uppercase tracking-wide opacity-80">Score</div>
+                  <div className="text-3xl sm:text-5xl font-bold leading-none">
+                    {runs}<span className="opacity-70">/</span>{wickets}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="text-base sm:text-2xl font-semibold leading-none">
+                    {overs}.{balls}<span className="ml-1 text-xs sm:text-sm font-normal opacity-80">ov</span>
+                  </div>
+                  <div className="text-xs sm:text-sm opacity-80 mt-1">RR {runRate.toFixed(2)}</div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
 
         {/* Main Counters */}
         <div className="grid grid-cols-3 gap-1.5 sm:gap-4">
@@ -349,7 +656,7 @@ function App() {
         </div>
 
         {/* Over Complete Badge */}
-        {isOverComplete && (
+        {isOverComplete && !isAllOut && (
           <div className="flex justify-center">
             <Badge variant="secondary" className="bg-accent text-accent-foreground">
               Over Complete - Ready for Next Over
@@ -357,11 +664,39 @@ function App() {
           </div>
         )}
 
+        {/* All Out Badge */}
+        {isAllOut && (
+          <div className="flex justify-center">
+            <Badge variant="destructive" className="gap-1">
+              <Warning size={12} />
+              All Out — Innings Over
+            </Badge>
+          </div>
+        )}
+
         {/* Current Over Details */}
         <Card className="bg-muted/30 py-2 sm:py-6 gap-1 sm:gap-6">
           <CardHeader className="pb-1 sm:pb-3 px-2 sm:px-6">
-            <CardTitle className="text-sm text-center">Current Over Details</CardTitle>
+            <button
+              type="button"
+              onClick={() => setOverDetailsOpen((o) => !o)}
+              aria-expanded={overDetailsOpen}
+              className="flex w-full items-center justify-between gap-2 text-left"
+            >
+              <span className="text-sm font-medium">Current Over Details</span>
+              <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                {!overDetailsOpen && (
+                  <span>
+                    {totalDeliveriesInOver === 0
+                      ? 'No deliveries yet'
+                      : `${totalDeliveriesInOver} ball${totalDeliveriesInOver > 1 ? 's' : ''} · ${widesInOver + noBallsInOver} extra${widesInOver + noBallsInOver === 1 ? '' : 's'} · ${wicketsInOver} wkt${wicketsInOver === 1 ? '' : 's'}`}
+                  </span>
+                )}
+                {overDetailsOpen ? <CaretUp size={14} /> : <CaretDown size={14} />}
+              </span>
+            </button>
           </CardHeader>
+          {overDetailsOpen && (
           <CardContent className="pt-0.5 sm:pt-2 px-2 sm:px-6">
               <div className="grid grid-cols-4 gap-1.5 sm:gap-3 text-center text-sm">
                 <div>
@@ -404,22 +739,18 @@ function App() {
                 <div className="mt-1.5 sm:mt-3 pt-1.5 sm:pt-3 border-t border-border">
                   <div className="text-xs text-muted-foreground mb-1 sm:mb-2 text-center hidden sm:block">Delivery sequence:</div>
                   <div className="flex flex-wrap justify-center gap-1">
-                    {currentOverDeliveries.map((delivery, index) => (
-                      <Badge 
-                        key={index}
-                        variant={delivery.type === 'legal' ? 'default' : 'secondary'}
-                        className={`text-xs ${
-                          delivery.type === 'legal' ? 'bg-primary text-primary-foreground' :
-                          delivery.type === 'wicket' ? 'bg-accent text-accent-foreground' :
-                          delivery.type === 'wide' ? 'bg-yellow-200 text-yellow-800' :
-                          'bg-orange-200 text-orange-800'
-                        }`}
-                      >
-                        {delivery.type === 'legal' ? '•' : 
-                         delivery.type === 'wicket' ? 'W' :
-                         delivery.type === 'wide' ? 'Wd' : 'NB'}
-                      </Badge>
-                    ))}
+                    {currentOverDeliveries.map((delivery, index) => {
+                      const chip = chipFor(delivery)
+                      return (
+                        <Badge 
+                          key={index}
+                          variant={delivery.type === 'legal' ? 'default' : 'secondary'}
+                          className={`text-xs ${chip.className}`}
+                        >
+                          {chip.label}
+                        </Badge>
+                      )
+                    })}
                   </div>
                 </div>
               )}
@@ -430,6 +761,7 @@ function App() {
                 </div>
               )}
             </CardContent>
+          )}
           </Card>
 
         {/* Delivery Buttons */}
@@ -438,62 +770,166 @@ function App() {
             <CardTitle className="text-base sm:text-lg text-center">Record Delivery</CardTitle>
           </CardHeader>
           <CardContent className="space-y-2 sm:space-y-4 px-2 sm:px-6">
-            <Button 
-              size="lg" 
-              className="w-full h-10 sm:h-16 text-base sm:text-lg font-semibold"
-              onClick={() => recordDelivery('legal')}
-              disabled={isAwaitingOverConfirmation}
-            >
-              Legal Delivery
-            </Button>
-            
-            <div className="grid grid-cols-3 gap-1.5 sm:gap-3">
-              <div className="flex flex-col items-center gap-1">
+            {scoringEnabled ? (
+              <>
+                {/* Run buttons (legal deliveries) */}
+                <div className="grid grid-cols-4 gap-1.5 sm:gap-3">
+                  {[0, 1, 2, 3, 4, 6].map((r) => (
+                    <Button
+                      key={r}
+                      size="lg"
+                      className="h-12 sm:h-16 text-lg sm:text-2xl font-bold"
+                      onClick={() => recordDelivery('legal', r)}
+                      disabled={deliveriesLocked}
+                    >
+                      {r === 0 ? '•' : r}
+                    </Button>
+                  ))}
+                  <Button
+                    size="lg"
+                    variant="secondary"
+                    className="h-12 sm:h-16 text-base sm:text-xl font-semibold"
+                    onClick={() => openPicker('legal')}
+                    disabled={deliveriesLocked}
+                  >
+                    5+
+                  </Button>
+                  <Button
+                    size="lg"
+                    className="h-12 sm:h-16 bg-accent text-accent-foreground hover:bg-accent/90"
+                    onClick={recordWicket}
+                    disabled={deliveriesLocked}
+                  >
+                    <Target size={16} className="mr-1 sm:size-5" />
+                    <span className="text-sm sm:text-base">Out</span>
+                  </Button>
+                </div>
+
+                {/* Extras */}
+                <div className="grid grid-cols-4 gap-1.5 sm:gap-3">
+                  <div className="flex flex-col items-center gap-1">
+                    <Button
+                      size="lg"
+                      className="w-full h-9 sm:h-14 text-sm sm:text-base bg-yellow-500 text-white hover:bg-yellow-600"
+                      onClick={() => openPicker('wide')}
+                      disabled={deliveriesLocked}
+                    >
+                      Wide
+                    </Button>
+                    {widesRebowled && (
+                      <Badge variant="outline" className="text-xs bg-yellow-50 text-yellow-700 border-yellow-200">
+                        Re-bowl
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex flex-col items-center gap-1">
+                    <Button
+                      size="lg"
+                      className="w-full h-9 sm:h-14 text-sm sm:text-base bg-orange-500 text-white hover:bg-orange-600"
+                      onClick={() => openPicker('no-ball')}
+                      disabled={deliveriesLocked}
+                    >
+                      No-ball
+                    </Button>
+                    {noBallsRebowled && (
+                      <Badge variant="outline" className="text-xs bg-orange-50 text-orange-700 border-orange-200">
+                        Re-bowl
+                      </Badge>
+                    )}
+                  </div>
+                  <Button
+                    size="lg"
+                    variant="outline"
+                    className="h-9 sm:h-14 text-sm sm:text-base"
+                    onClick={() => openPicker('bye')}
+                    disabled={deliveriesLocked}
+                  >
+                    Bye
+                  </Button>
+                  <Button
+                    size="lg"
+                    variant="outline"
+                    className="h-9 sm:h-14 text-sm sm:text-base"
+                    onClick={() => openPicker('leg-bye')}
+                    disabled={deliveriesLocked}
+                  >
+                    Leg-bye
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
                 <Button 
                   size="lg" 
-                  className="w-full h-8 sm:h-14 text-sm sm:text-base bg-yellow-500 text-white hover:bg-yellow-600"
-                  onClick={() => recordDelivery('wide')}
-                  disabled={isAwaitingOverConfirmation}
+                  className="w-full h-10 sm:h-16 text-base sm:text-lg font-semibold"
+                  onClick={() => recordDelivery('legal')}
+                  disabled={deliveriesLocked}
                 >
-                  Wide
+                  Legal Delivery
                 </Button>
-                {widesRebowled && (
-                  <Badge variant="outline" className="text-xs bg-yellow-50 text-yellow-700 border-yellow-200">
-                    Re-bowl
-                  </Badge>
-                )}
-              </div>
-              <div className="flex flex-col items-center gap-1">
-                <Button 
-                  size="lg"
-                  className="w-full h-8 sm:h-14 text-sm sm:text-base bg-orange-500 text-white hover:bg-orange-600"
-                  onClick={() => recordDelivery('no-ball')}
-                  disabled={isAwaitingOverConfirmation}
-                >
-                  No-ball
-                </Button>
-                {noBallsRebowled && (
-                  <Badge variant="outline" className="text-xs bg-orange-50 text-orange-700 border-orange-200">
-                    Re-bowl
-                  </Badge>
-                )}
-              </div>
-              <Button 
-                size="lg"
-                variant="default"
-                className="h-8 sm:h-14 bg-accent text-accent-foreground hover:bg-accent/90"
-                onClick={recordWicket}
-                disabled={isAwaitingOverConfirmation}
-              >
-                <Target size={14} className="mr-1 sm:mr-2 sm:size-5" />
-                <span className="text-sm sm:text-base">Wicket</span>
-              </Button>
-            </div>
+                
+                <div className="grid grid-cols-3 gap-1.5 sm:gap-3">
+                  <div className="flex flex-col items-center gap-1">
+                    <Button 
+                      size="lg" 
+                      className="w-full h-8 sm:h-14 text-sm sm:text-base bg-yellow-500 text-white hover:bg-yellow-600"
+                      onClick={() => recordDelivery('wide')}
+                      disabled={deliveriesLocked}
+                    >
+                      Wide
+                    </Button>
+                    {widesRebowled && (
+                      <Badge variant="outline" className="text-xs bg-yellow-50 text-yellow-700 border-yellow-200">
+                        Re-bowl
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex flex-col items-center gap-1">
+                    <Button 
+                      size="lg"
+                      className="w-full h-8 sm:h-14 text-sm sm:text-base bg-orange-500 text-white hover:bg-orange-600"
+                      onClick={() => recordDelivery('no-ball')}
+                      disabled={deliveriesLocked}
+                    >
+                      No-ball
+                    </Button>
+                    {noBallsRebowled && (
+                      <Badge variant="outline" className="text-xs bg-orange-50 text-orange-700 border-orange-200">
+                        Re-bowl
+                      </Badge>
+                    )}
+                  </div>
+                  <Button 
+                    size="lg"
+                    variant="default"
+                    className="h-8 sm:h-14 bg-accent text-accent-foreground hover:bg-accent/90"
+                    onClick={recordWicket}
+                    disabled={deliveriesLocked}
+                  >
+                    <Target size={14} className="mr-1 sm:mr-2 sm:size-5" />
+                    <span className="text-sm sm:text-base">Wicket</span>
+                  </Button>
+                </div>
+              </>
+            )}
           </CardContent>
         </Card>
 
         {/* Undo and Reset Buttons */}
         <div className="flex flex-col gap-1.5 sm:gap-3">
+          {/* Set / Resume Score Button */}
+          <div className="flex justify-center">
+            <Button
+              variant="outline"
+              size="lg"
+              onClick={openManualEntry}
+              className="h-8 sm:h-14 w-full max-w-xs"
+            >
+              <Pencil size={14} className="mr-1 sm:mr-2 sm:size-5" />
+              <span className="text-sm sm:text-base">Set / Resume Score</span>
+            </Button>
+          </div>
+
           {/* Undo Button */}
           <div className="flex justify-center">
             <Button 
@@ -548,7 +984,7 @@ function App() {
                 <DialogHeader>
                   <DialogTitle>Reset All Counters</DialogTitle>
                   <DialogDescription>
-                    This will reset balls, overs, and wickets to zero. This action can be undone.
+                    This will reset runs, balls, overs, and wickets to zero. This action can be undone.
                   </DialogDescription>
                 </DialogHeader>
                 <DialogFooter>
@@ -581,20 +1017,200 @@ function App() {
             </div>
             <div className="text-sm space-y-1 sm:space-y-2">
               <div className="flex justify-between">
+                <span>Scoring:</span>
+                <span className={scoringEnabled ? "text-accent" : "text-muted-foreground"}>
+                  {scoringEnabled ? "On" : "Off"}
+                </span>
+              </div>
+              <div className="flex justify-between">
                 <span>Wides:</span>
                 <span className={widesRebowled ? "text-accent" : "text-muted-foreground"}>
-                  {widesRebowled ? "Re-bowled" : "Count as ball"}
+                  {widesRebowled ? "Re-bowled" : "Count as ball"}{scoringEnabled ? ` · +${widePenalty}` : ""}
                 </span>
               </div>
               <div className="flex justify-between">
                 <span>No-balls:</span>
                 <span className={noBallsRebowled ? "text-accent" : "text-muted-foreground"}>
-                  {noBallsRebowled ? "Re-bowled" : "Count as ball"}
+                  {noBallsRebowled ? "Re-bowled" : "Count as ball"}{scoringEnabled ? ` · +${noBallPenalty}` : ""}
                 </span>
               </div>
             </div>
           </CardContent>
         </Card>
+
+        {/* Run Picker (scoring mode) */}
+        <Dialog open={picker.open} onOpenChange={(open) => setPicker((p) => ({ ...p, open }))}>
+          <DialogContent className="sm:max-w-xs">
+            <DialogHeader>
+              <DialogTitle>
+                {picker.mode === 'legal' ? 'Runs scored' :
+                 picker.mode === 'wide' ? 'Wide — extra runs run' :
+                 picker.mode === 'no-ball' ? 'No-ball — extra runs run' :
+                 picker.mode === 'bye' ? 'Byes' : 'Leg-byes'}
+              </DialogTitle>
+              <DialogDescription>
+                {picker.mode === 'wide'
+                  ? `A ${widePenalty}-run penalty is added automatically.`
+                  : picker.mode === 'no-ball'
+                    ? `A ${noBallPenalty}-run penalty is added automatically.`
+                    : 'How many runs were taken?'}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid grid-cols-3 gap-2 py-2">
+              {[0, 1, 2, 3, 4, 5].map((r) => (
+                <Button
+                  key={r}
+                  size="lg"
+                  variant="outline"
+                  className="h-14 text-xl font-bold"
+                  onClick={() => handlePickRuns(r)}
+                >
+                  {r}
+                </Button>
+              ))}
+            </div>
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                min={0}
+                inputMode="numeric"
+                placeholder="Other"
+                value={customRuns}
+                onChange={(e) => setCustomRuns(e.target.value)}
+                className="text-center"
+              />
+              <Button
+                onClick={() => {
+                  const n = parseInt(customRuns, 10)
+                  if (isNaN(n) || n < 0) {
+                    toast.error('Enter a valid number of runs')
+                    return
+                  }
+                  handlePickRuns(n)
+                }}
+              >
+                <Plus size={16} className="mr-1" />
+                Add
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+
+        {/* Manual Set / Resume Score */}
+        <Dialog open={showManualEntry} onOpenChange={setShowManualEntry}>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Set / resume score</DialogTitle>
+              <DialogDescription>
+                Picking up mid-innings? Enter the current state to carry on from here.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-4 py-2">
+              {scoringEnabled && (
+                <div className="space-y-1">
+                  <Label htmlFor="manual-runs">Runs</Label>
+                  <Input
+                    id="manual-runs"
+                    type="number"
+                    min={0}
+                    inputMode="numeric"
+                    value={manualRuns}
+                    onChange={(e) => setManualRuns(e.target.value)}
+                    placeholder="e.g. 87"
+                    aria-invalid={!!manualRunsError}
+                    className={manualRunsError ? "border-destructive focus-visible:ring-destructive" : ""}
+                  />
+                  {manualRunsError && (
+                    <p className="text-xs text-destructive">{manualRunsError}</p>
+                  )}
+                </div>
+              )}
+              <div className="space-y-1">
+                <Label htmlFor="manual-wickets">Wickets down</Label>
+                <Input
+                  id="manual-wickets"
+                  type="number"
+                  min={0}
+                  max={9}
+                  inputMode="numeric"
+                  value={manualWickets}
+                  onChange={(e) => setManualWickets(e.target.value)}
+                  placeholder="e.g. 3"
+                  aria-invalid={!!manualWicketsError}
+                  className={manualWicketsError ? "border-destructive focus-visible:ring-destructive" : ""}
+                />
+                {manualWicketsError && (
+                  <p className="text-xs text-destructive">{manualWicketsError}</p>
+                )}
+              </div>
+              <div className="space-y-1">
+                <Label htmlFor="manual-overs">Overs bowled</Label>
+                <Input
+                  id="manual-overs"
+                  type="text"
+                  inputMode="decimal"
+                  value={manualOvers}
+                  onChange={(e) => setManualOvers(e.target.value)}
+                  placeholder="e.g. 11.3"
+                  aria-invalid={!!manualOversError}
+                  className={manualOversError ? "border-destructive focus-visible:ring-destructive" : ""}
+                />
+                {manualOversError ? (
+                  <p className="text-xs text-destructive">{manualOversError}</p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    Format: completed overs.balls into the current over (0–5), e.g. 11.3
+                  </p>
+                )}
+              </div>
+              {hasMatchData && (
+                <p className="text-xs text-destructive">
+                  This replaces the current match data and clears this over's ball-by-ball and undo history.
+                </p>
+              )}
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setShowManualEntry(false)}>
+                Cancel
+              </Button>
+              <Button onClick={applyManualEntry} disabled={!canApplyManual}>
+                {hasMatchData ? 'Overwrite & set' : 'Set score'}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        {/* All Out (innings over) */}
+        <Dialog open={showAllOutDialog} onOpenChange={setShowAllOutDialog}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Warning size={20} className="text-destructive" />
+                All out!
+              </DialogTitle>
+              <DialogDescription>
+                10 wickets have fallen — the innings is over.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="py-2 text-center">
+              <div className="text-3xl font-bold text-primary">
+                {scoringEnabled ? `${runs}/${wickets}` : `${wickets} all out`}
+              </div>
+              <div className="text-sm text-muted-foreground mt-1">
+                {overs}.{balls} overs
+              </div>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setShowAllOutDialog(false)}>
+                Close
+              </Button>
+              <Button onClick={resetCounters}>
+                <ArrowCounterClockwise size={16} className="mr-1" />
+                New innings
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Adds an optional, **on-by-default** scoring mode so umpires can keep the score as well as officiate, making the app more engaging to use during a game. With scoring **off**, the app behaves exactly as before (single "Legal Delivery" button, no runs, no scoreboard).

## What's included

- **Team total & scoreboard** — running `runs/wickets`, overs and current run rate. Per-ball run buttons (`• 1 2 3 4 6`, plus `5+` for unusual scores) replace the single Legal Delivery button when scoring is on.
- **Extras & byes** — Wide / No-ball / Bye / Leg-bye each open a quick run picker. Wides and no-balls add a **configurable penalty** (default 1), set beside the re-bowl toggles.
- **All out** — wickets are capped at **10**; the 10th wicket triggers an **"All out!"** popup and locks deliveries until reset/undo/resume.
- **Collapsible Current Over Details** — collapsed by default in scoring mode to save space, with a compact summary while collapsed.
- **Over-complete recap** — the over-complete dialog now shows the **runs scored that over** and the **score total** (scoring mode only).
- **Set / Resume Score** — manually enter current runs, wickets and overs (`overs.balls`, e.g. `11.3`) to pick up mid-innings, with **live validation** that blocks impossible values (10+ wickets, `12.6`, `11.9`, …).

## Validation

- `npx tsc -b` (full type-check) — exit 0
- `npm run build` (`tsc -b --noCheck && vite build`) — success
- Manual smoke test via local dev server (`localhost:5173`)

## Docs

`PRD.md` and `README.md` updated to cover scoring mode, the all-out cap, the collapsible over-details card, the over-complete recap, and the manual set/resume validation.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>